### PR TITLE
Fix shepherd not working after error during computation

### DIFF
--- a/shepherd/shepherd/shepherd.py
+++ b/shepherd/shepherd/shepherd.py
@@ -281,7 +281,7 @@ class Shepherd:
                 sheep = self._get_sheep(sheep_id)
                 message = await Messenger.recv(sheep.socket, [DoneMessage, ErrorMessage], noblock=True)
                 job_id = message.job_id
-                
+
                 # clean-up the working directory and upload the results
                 working_directory = path.join(self._get_sheep(sheep_id).sheep_data_root, job_id)
                 await self._storage.push_job_data(job_id, working_directory)

--- a/shepherd/shepherd/shepherd.py
+++ b/shepherd/shepherd/shepherd.py
@@ -281,6 +281,7 @@ class Shepherd:
                 sheep = self._get_sheep(sheep_id)
                 message = await Messenger.recv(sheep.socket, [DoneMessage, ErrorMessage], noblock=True)
                 job_id = message.job_id
+                
                 # clean-up the working directory and upload the results
                 working_directory = path.join(self._get_sheep(sheep_id).sheep_data_root, job_id)
                 await self._storage.push_job_data(job_id, working_directory)
@@ -297,7 +298,7 @@ class Shepherd:
                     # notify about the finished job
                     async with self.job_done_condition:
                         self.job_done_condition.notify_all()
-                        
+
                 elif isinstance(message, ErrorMessage):
                     error = ErrorModel({
                         "message": message.message,


### PR DESCRIPTION
Když během výpočtu (ten dělá `Runner` pod `Sheep`) došlo k erroru, pošle `Sheep` `ErrorMessage` . Tuto message přijme `Shepherd` ve funkci `shepherd._listen`, ktera bezi jako `asyncio task`.

`ErrorMessage` to prijme vporadku, ale pak to spadne na `self._job_status.pop(job_id)`, protoze to uz se dela `_report_job_failed`, ktery se vola par radku nahore. Na opravu toho tedy staci tento radek odstranit, pak to ale nove pada na `logging.info('Job `%s` from sheep `%s` failed (%s)', job_id, sheep_id, message.short_error)`, protoze `Message` zadny atribut `short_error` nema. Spravne tam chceme logovat `message.message`.