### PR TITLE
Fix shepherd not working after error during computation - old-shepherd

### DIFF
--- a/shepherd/shepherd/shepherd.py
+++ b/shepherd/shepherd/shepherd.py
@@ -300,12 +300,11 @@ class Shepherd:
                         "exception_traceback": message.exception_traceback
                     })
                     await self._report_job_failed(job_id, error, sheep)
-                    self._job_status.pop(job_id)
-                    logging.info('Job `%s` from sheep `%s` failed (%s)', job_id, sheep_id, message.short_error)
+                    logging.info('Job `%s` from sheep `%s` failed (%s)', job_id, sheep_id, message.message)
 
-                # notify about the finished job
                 sheep.in_progress.remove(job_id)
 
+                # notify about the finished job
                 async with self.job_done_condition:
                     self.job_done_condition.notify_all()
 

--- a/shepherd/shepherd/shepherd.py
+++ b/shepherd/shepherd/shepherd.py
@@ -293,6 +293,11 @@ class Shepherd:
                     status.finished_at = datetime.utcnow()
                     await self._job_status_update_queue.enqueue_task(self._storage.set_job_status(job_id, status.copy()))
                     logging.info('Job `%s` from sheep `%s` done', job_id, sheep_id)
+                    
+                    # notify about the finished job
+                    async with self.job_done_condition:
+                        self.job_done_condition.notify_all()
+
                 elif isinstance(message, ErrorMessage):
                     error = ErrorModel({
                         "message": message.message,
@@ -303,11 +308,7 @@ class Shepherd:
                     logging.info('Job `%s` from sheep `%s` failed (%s)', job_id, sheep_id, message.message)
 
                 sheep.in_progress.remove(job_id)
-
-                # notify about the finished job
-                async with self.job_done_condition:
-                    self.job_done_condition.notify_all()
-
+                
     def get_status(self) -> Generator[Tuple[str, SheepModel], None, None]:
         """
         Get status information for all sheep


### PR DESCRIPTION
Z old-shepherd uděláme nový release původního shepherda, ať nemusíme zasahovat do toho repositáře iteraitu a na ikem produkci budeme docker image shepherda instalovat pomoci tohoto repositáře.


Když během výpočtu (ten dělá `Runner` pod `Sheep`) došlo k erroru, pošle `Sheep` `ErrorMessage` . Tuto message přijme `Shepherd` ve funkci `shepherd._listen`, ktera bezi jako `asyncio task`.

`ErrorMessage` to prijme vporadku, ale pak to spadne na `self._job_status.pop(job_id)`, protoze to uz se dela `_report_job_failed`, ktery se vola par radku nahore. Na opravu toho tedy staci tento radek odstranit, pak to ale nove pada na `logging.info('Job `%s` from sheep `%s` failed (%s)', job_id, sheep_id, message.short_error)`, protoze `Message` zadny atribut `short_error` nema. Spravne tam chceme logovat `message.message`.